### PR TITLE
Fixed Export with NextJS's getServerSideProps() method

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -38,4 +38,5 @@ export const initialSettings: Settings = {
 };
 
 export const ON_DEMAND_TOKEN = 'OnDemandToken';
+export const TEMP_TOKEN = 'TempToken';
 

--- a/functions/datastore/appointments.js
+++ b/functions/datastore/appointments.js
@@ -255,12 +255,12 @@ exports.handler = async function(context, event, callback) {
       }
 
       case 'ADD': {
-        assert(event.appointment, 'Mssing event.appointment!!!');
+        assert(event.appointment, 'Missing event.appointment!!!');
         const appointment = event.appointment;
-        assert(appointment.appointment_reason, 'Mssing appointment_reason!!!');
-        assert(appointment.appointment_references, 'Mssing appointment_references!!!');
-        assert(appointment.patient_id, 'Mssing patient_id!!!');
-        assert(appointment.provider_id, 'Mssing provider_id!!!');
+        assert(appointment.appointment_reason, 'Missing appointment_reason!!!');
+        assert(appointment.appointment_references, 'Missing appointment_references!!!');
+        assert(appointment.patient_id, 'Missing patient_id!!!');
+        assert(appointment.provider_id, 'Missing provider_id!!!');
         const TWILIO_SYNC_SID = await getParam(context, 'TWILIO_SYNC_SID');
 
         const now = new Date();
@@ -290,7 +290,7 @@ exports.handler = async function(context, event, callback) {
       }
 
       case 'REMOVE': {
-        assert(event.appointment_id, 'Mssing event.appointment_id!!!');
+        assert(event.appointment_id, 'Missing event.appointment_id!!!');
         const TWILIO_SYNC_SID = await getParam(context, 'TWILIO_SYNC_SID');
 
         const resources = await read_fhir(context, TWILIO_SYNC_SID, FHIR_APPOINTMENT);

--- a/functions/datastore/contents.js
+++ b/functions/datastore/contents.js
@@ -170,10 +170,10 @@ exports.handler = async function(context, event, callback) {
       }
 
       case 'ADD': {
-        assert(event.content, 'Mssing event.content!!!');
+        assert(event.content, 'Missing event.content!!!');
         const content = JSON.parse(event.content);
-        assert(content.content_title, 'Mssing content_title!!!');
-        assert(content.content_video_url, 'Mssing content_video_url!!!');
+        assert(content.content_title, 'Missing content_title!!!');
+        assert(content.content_video_url, 'Missing content_video_url!!!');
         const TWILIO_SYNC_SID = await getParam(context, 'TWILIO_SYNC_SID');
 
         const now = new Date();
@@ -203,8 +203,8 @@ exports.handler = async function(context, event, callback) {
       }
 
       case 'ASSIGN': {
-        assert(event.content_id, 'Mssing event.content_id!!!');
-        assert(event.provider_id, 'Mssing event.provider_id!!!');
+        assert(event.content_id, 'Missing event.content_id!!!');
+        assert(event.provider_id, 'Missing event.provider_id!!!');
         const TWILIO_SYNC_SID = await getParam(context, 'TWILIO_SYNC_SID');
 
         const resources = await read_fhir(context, TWILIO_SYNC_SID, FHIR_DOCUMENT_REFERENCE);

--- a/functions/datastore/patients.js
+++ b/functions/datastore/patients.js
@@ -225,16 +225,16 @@ exports.handler = async function(context, event, callback) {
       }
 
       case 'ADD': {
-        assert(event.patient, 'Mssing event.patient!!!');
+        assert(event.patient, 'Missing event.patient!!!');
         const patient = event.patient;
-        assert(patient.patient_name, 'Mssing patient_name!!!');
-        assert(patient.patient_family_name, 'Mssing patient_family_name!!!');
-        assert(patient.patient_given_name, 'Mssing patient_given_name!!!');
-        assert(patient.patient_phone, 'Mssing patient_phone!!!');
-        assert(patient.patient_gender, 'Mssing patient_gender!!!');
-        assert(patient.patient_language, 'Mssing patient_language!!!');
-        assert(patient.patient_medications, 'Mssing patient_medications!!!');
-        assert(patient.patient_conditions, 'Mssing patient_conditions!!!');
+        assert(patient.patient_name, 'Missing patient_name!!!');
+        assert(patient.patient_family_name, 'Missing patient_family_name!!!');
+        assert(patient.patient_given_name, 'Missing patient_given_name!!!');
+        assert(patient.patient_phone, 'Missing patient_phone!!!');
+        assert(patient.patient_gender, 'Missing patient_gender!!!');
+        assert(patient.patient_language, 'Missing patient_language!!!');
+        assert(patient.patient_medications, 'Missing patient_medications!!!');
+        assert(patient.patient_conditions, 'Missing patient_conditions!!!');
         const TWILIO_SYNC_SID = await getParam(context, 'TWILIO_SYNC_SID');
 
         const now = new Date();


### PR DESCRIPTION
<!-- Describe your Pull Request -->
NextJS's getServerSideProps() method fetches data pre-render but it is disabled when using ```npm run export```
- I fixed it by moving the pre-render fetch to a useEffect() hook in the received.tsx component.  This makes the app slower but works such that we can export the build statically for Docker to build.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
