### PR TITLE
THV2-90 underscore in sms for android devices

### DIFF
--- a/app/services/authService.ts
+++ b/app/services/authService.ts
@@ -9,10 +9,17 @@ type UserJwtToken = {
     name?: string
 }
 
+/** for some reason twilio API sends broken SMS with '§' instead of '_' in the text to Android devices (mainly because of ASCII/GSM charset difference)
+ * return it back here
+*/
+function modifyPasscode(passcode: string): string {
+    return passcode.replace('§','_')
+} 
+
 function authenticateVisitorOrPatient(passcode: string): Promise<PatientUser> {
     return fetch(Uris.get(Uris.visits.token), {
         method: 'POST',
-        body: JSON.stringify({ action: "TOKEN", passcode }),
+        body: JSON.stringify({ action: "TOKEN", passcode: modifyPasscode(passcode) }),
         headers: { 
             'Accept': 'application/json',
             'Content-Type': 'application/json'
@@ -33,7 +40,7 @@ function authenticateVisitorOrPatient(passcode: string): Promise<PatientUser> {
 function authenticatePractitioner(passcode: string): Promise<ProviderUser> {
     return fetch(Uris.get(Uris.visits.token), {
         method: 'POST',
-        body: JSON.stringify({ action: "TOKEN", passcode }),
+        body: JSON.stringify({ action: "TOKEN", passcode: modifyPasscode(passcode) }),
         headers: { 
             'Accept': 'application/json',
             'Content-Type': 'application/json'


### PR DESCRIPTION
Replace §  to _  in token
For some reason twilio API sends broken SMS with '§' instead of '_' in the text to Android devices (mainly because of ASCII/GSM charset difference)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
